### PR TITLE
pin pandas below 2.0

### DIFF
--- a/conda-requirements.yml
+++ b/conda-requirements.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - liblsl
 - numpy
-- pandas
+- pandas<2.0
 - pip
 - PyOpenGL
 - PySide2


### PR DESCRIPTION
I get an error when starting:
```
AttributeError: 'DataFrame' object has no attribute 'append'. Did you mean: '_append'?
````
(sorry, lost the full backtrace).

It seems append was removed in pandas 2.0, so pinning the package for now.